### PR TITLE
Added callbacks to prevent warnings

### DIFF
--- a/build/modules/concat.js
+++ b/build/modules/concat.js
@@ -25,7 +25,9 @@ NOAH.concat = (function(options) {
 
     mkdirp(getDirName(dest), function (err) {
       if (err) return cb(err);
-      fs.writeFile(dest, out.join('\n'));
+      fs.writeFile(dest, out.join('\n'), (err) => {
+         if (err) throw err;
+      });
     });
 
     console.log(' ' + dest + ' built.');

--- a/build/modules/sass.js
+++ b/build/modules/sass.js
@@ -24,7 +24,9 @@ NOAH.sass = (function(options) {
 
     mkdirp(getDirName(options.dest), function(err) {
       if (err) return cb(err);
-      fs.writeFile(options.dest, result.css);
+      fs.writeFile(options.dest, result.css, (err) => {
+        if (err) throw err;
+      });
     });
 
     console.log(' ' + options.dest + ' built.');

--- a/build/modules/uglify.js
+++ b/build/modules/uglify.js
@@ -8,7 +8,7 @@ var NOAH = NOAH || {};
  */
 NOAH.uglify = (function(options) {
 
-    // Requirements 
+    // Requirements
     var fs = require('fs');
     var UglifyJS = require('uglify-js');
     var mkdirp = require('mkdirp');
@@ -22,7 +22,9 @@ NOAH.uglify = (function(options) {
 
     mkdirp(getDirName(dest), function (err) {
       if (err) return cb(err);
-      fs.writeFile(dest, result.code);
+      fs.writeFile(dest, result.code, (err) => {
+        if (err) throw err;
+      });
     });
 
     console.log(' ' + dest + ' built.');


### PR DESCRIPTION
This PR closes #7

This changes prevent lots of DeprecationWarning when running `copy`, `sass`, `uglify` tasks, that uses the `fs.writeFile(...)` function without callback.