### PR TITLE
Need small timeout to avoid fs read errors

### DIFF
--- a/build/modules/sass.js
+++ b/build/modules/sass.js
@@ -17,19 +17,21 @@ NOAH.sass = (function(options) {
     // Options
     var style = options.style || 'expanded';
 
-    var result = sass.renderSync({
-        file: options.src,
-        outputStyle: style
-    });
+    setTimeout(() => {
+        var result = sass.renderSync({
+            file: options.src,
+            outputStyle: style
+        });
 
-    mkdirp(getDirName(options.dest), function(err) {
-      if (err) return cb(err);
-      fs.writeFile(options.dest, result.css, (err) => {
-        if (err) throw err;
-      });
-    });
+        mkdirp(getDirName(options.dest), function(err) {
+          if (err) return cb(err);
+          fs.writeFile(options.dest, result.css, (err) => {
+            if (err) throw err;
+          });
+        });
 
-    console.log(' ' + options.dest + ' built.');
+        console.log(' ' + options.dest + ' built.');
+    }, 50);
 });
 
 // Export the function to use in other files


### PR DESCRIPTION
### Problem

When save a SCSS file, the file isn't ready instantly, so, to avoid node-sass fs read errors we need to add a small timeout.

This is an error from `chokidar`, and reading about it, the timeout is the perfect work-a-round.

I have tested with 10ms, 20ms, but the error persist, with 50ms solve the error.

I don't test if other watchers give the same error (JS, etc).

### Error

```
yarn serve
.
.
.
[Browsersync] Access URLs:
 ---------------------------------------
       Local: http://localhost:3000
    External: http://192.168.x.x:3000
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://192.168.x.x:3001
 ---------------------------------------
[Browsersync] Serving files from: ./dist
[Browsersync] Watching files...
D:\Projetos\Noah\node_modules\node-sass\lib\index.js:434
  throw assign(new Error(), JSON.parse(result.error));
  ^

Error: File to read not found or unreadable: D:/Projetos/Noah/assets/scss/example.scss
    at Object.module.exports.renderSync (D:\Projetos\Noah\node_modules\node-sass\lib\index.js:434:16)
    at Object.NOAH.sass (D:\Projetos\Noah\build\modules\sass.js:21:27)
    at FSWatcher.<anonymous> (D:\Projetos\Noah\build\tasks\browser-sync.js:34:12)
    at emitThree (events.js:116:13)
    at FSWatcher.emit (events.js:194:7)
    at FSWatcher.<anonymous> (D:\Projetos\Noah\node_modules\chokidar\index.js:197:38)
    at FSWatcher._emit (D:\Projetos\Noah\node_modules\chokidar\index.js:238:5)
    at FSWatcher.<anonymous> (D:\Projetos\Noah\node_modules\chokidar\lib\nodefs-handler.js:263:16)
    at FSReqWrap.oncomplete (fs.js:123:15)

npm ERR! Windows_NT 6.1.7601
npm ERR! argv "D:\\Programas\\nodejs\\node.exe" "D:\\Programas\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "browsersync"
npm ERR! node v6.11.0
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! noah-npm@1.0.0 browsersync: `node ./build/tasks/browser-sync.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the noah-npm@1.0.0 browsersync script 'node ./build/tasks/browser-sync.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the noah-npm package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node ./build/tasks/browser-sync.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs noah-npm
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls noah-npm
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     D:\Projetos\Noah\npm-debug.log
ERROR: "browsersync" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```